### PR TITLE
Do not produce temp and debug files

### DIFF
--- a/sdf_timing/sdfyacc.py
+++ b/sdf_timing/sdfyacc.py
@@ -541,4 +541,4 @@ def p_error(p):
     raise Exception("Syntax error at '%s' line: %d" % (p.value, p.lineno))
 
 
-parser = yacc.yacc()
+parser = yacc.yacc(debug=False, write_tables=False)


### PR DESCRIPTION
If installed in readonly directory the package fails on creation of tmp and debug files
