### PR TITLE
Add get_scale_{seconds,fs}() to parse SDF

### DIFF
--- a/sdf_timing/utils.py
+++ b/sdf_timing/utils.py
@@ -21,6 +21,13 @@ def get_scale_fs(timescale):
 
     >>> get_scale_fs('100 s')
     100000000000000000
+
+    >>> try:
+    ...     get_scale_fs('2s')
+    ... except AssertionError as e:
+    ...     print(e)
+    Invalid SDF timescale 2s
+
     """
     mm = re.match(r'(10{0,2})(\.0)? *([munpf]?s)', timescale)
     sc_lut = {
@@ -31,11 +38,10 @@ def get_scale_fs(timescale):
         'ps': 1e3,
         'fs': 1,
     }
-    ret = None
-    if mm:
-        base, _, sc = mm.groups()
-        ret = int(base) * int(sc_lut[sc])
-    return ret
+    assert mm is not None, "Invalid SDF timescale {}".format(timescale)
+
+    base, _, sc = mm.groups()
+    return int(base) * int(sc_lut[sc])
 
 
 def get_scale_seconds(timescale):

--- a/sdf_timing/utils.py
+++ b/sdf_timing/utils.py
@@ -1,3 +1,42 @@
+import re
+
+
+def get_scale(timescale):
+    """Convert sdf timescale to scale factor
+
+    >>> get_scale('1.0 fs')
+    1e-15
+
+    >>> get_scale('1ps')
+    1e-12
+
+    >>> get_scale('10 ns')
+    1e-08
+
+    >>> get_scale('10.0 us')
+    9.999999999999999e-06
+
+    >>> get_scale('100.0ms')
+    0.1
+
+    >>> get_scale('100 s')
+    100.0
+
+    """
+    mm = re.match(r'(10{0,2})(\.0)? *([munpf]?s)', timescale)
+    sc_lut = {
+        's': 1.0,
+        'ms': 1e-3,
+        'us': 1e-6,
+        'ns': 1e-9,
+        'ps': 1e-12,
+        'fs': 1e-15,
+    }
+    ret = None
+    if mm:
+        base, _, sc = mm.groups()
+        ret = int(base) * sc_lut[sc]
+    return ret
 
 
 def prepare_entry(name=None,

--- a/sdf_timing/utils.py
+++ b/sdf_timing/utils.py
@@ -1,42 +1,65 @@
 import re
 
 
-def get_scale(timescale):
-    """Convert sdf timescale to scale factor
+def get_scale_fs(timescale):
+    """Convert sdf timescale to scale factor to femtoseconds as int
 
-    >>> get_scale('1.0 fs')
-    1e-15
+    >>> get_scale_fs('1.0 fs')
+    1
 
-    >>> get_scale('1ps')
-    1e-12
+    >>> get_scale_fs('1ps')
+    1000
 
-    >>> get_scale('10 ns')
-    1e-08
+    >>> get_scale_fs('10 ns')
+    10000000
 
-    >>> get_scale('10.0 us')
-    9.999999999999999e-06
+    >>> get_scale_fs('10.0 us')
+    10000000000
 
-    >>> get_scale('100.0ms')
-    0.1
+    >>> get_scale_fs('100.0ms')
+    100000000000000
 
-    >>> get_scale('100 s')
-    100.0
-
+    >>> get_scale_fs('100 s')
+    100000000000000000
     """
     mm = re.match(r'(10{0,2})(\.0)? *([munpf]?s)', timescale)
     sc_lut = {
-        's': 1.0,
-        'ms': 1e-3,
-        'us': 1e-6,
-        'ns': 1e-9,
-        'ps': 1e-12,
-        'fs': 1e-15,
+        's': 1e15,
+        'ms': 1e12,
+        'us': 1e9,
+        'ns': 1e6,
+        'ps': 1e3,
+        'fs': 1,
     }
     ret = None
     if mm:
         base, _, sc = mm.groups()
-        ret = int(base) * sc_lut[sc]
+        ret = int(base) * int(sc_lut[sc])
     return ret
+
+
+def get_scale_seconds(timescale):
+    """Convert sdf timescale to scale factor to floating point seconds
+
+    >>> get_scale_seconds('1.0 fs')
+    1e-15
+
+    >>> get_scale_seconds('1ps')
+    1e-12
+
+    >>> get_scale_seconds('10 ns')
+    1e-08
+
+    >>> get_scale_seconds('10.0 us')
+    1e-05
+
+    >>> get_scale_seconds('100.0ms')
+    0.1
+
+    >>> round(get_scale_seconds('100 s'), 6)
+    100.0
+    """
+    return 1e-15 * get_scale_fs(timescale)
 
 
 def prepare_entry(name=None,

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ commands =
     # used by parser. This triggers flake8 error. Let's ignore this for now.
     flake8 --ignore F401 .
     py.test tests
+    py.test --doctest-modules sdf_timing
 [flake8]
 exclude = .tox,*.egg,build,data
 select = E,W,F


### PR DESCRIPTION
`get_scale_seonds()` returns timescale in seconds
`get_scale_fs()` return timescale as int femtoseconds